### PR TITLE
Fix: 신규 일정(서류/면접) 추가시 job_collection doc 신규 생성

### DIFF
--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -166,7 +166,7 @@ export default function Calendar() {
   useEffect(() => {
     getPosts()
   }, [session])
-
+  console.log(posts)
   return (
     <div className={calendar_container}>
       {/* 일정 추가 버튼 */}

--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -166,7 +166,7 @@ export default function Calendar() {
   useEffect(() => {
     getPosts()
   }, [session])
-  console.log(posts)
+
   return (
     <div className={calendar_container}>
       {/* 일정 추가 버튼 */}

--- a/src/components/ModalInterview.js
+++ b/src/components/ModalInterview.js
@@ -59,15 +59,26 @@ export default function Modal({
       alert("빈 칸을 채워주세요");
       return;
     }
+    let newPost
 
-    const newPost = {
-      jobId: selectedPaperPost ? selectedJobId : Math.random().toString(36).substring(2, 11),
-      date: dateValue,
-      type: "interview",
-      company: selectedPaperPost ? selectedPaperPost.company : companyValue,
-      job: selectedPaperPost ? selectedPaperPost.job : jobValue,
-      postLink: selectedPaperPost ? selectedPaperPost.postLink : postLinkValue?.trim(),
-    };
+   if (selectedPaperPost) {
+      newPost = {
+       date: dateValue,
+       type: "interview",
+       company: selectedPaperPost.company,
+       job: selectedPaperPost.job,
+       postLink: selectedPaperPost.postLink,
+       jobId: selectedPaperPost.jobId,
+     };
+   } else {
+      newPost = {
+       date: dateValue,
+       type: "interview",
+       company: companyValue,
+       job: jobValue,
+       postLink: postLinkValue.trim(),
+     };
+   }
 
     const isAlreadyRegistered = posts.some((post) => {
       return (
@@ -89,7 +100,8 @@ export default function Modal({
     })
       .then((res) => res.json())
       .then((data) => {
-        newPost.id = data;
+        newPost.id = data.docId;
+        newPost.jobId = selectedPaperPost ? selectedJobId : data.jobId,
         setPosts((prevJobPosts) => [...prevJobPosts, newPost]);
         setModalInterview(false);
       })

--- a/src/components/ModalPaper.js
+++ b/src/components/ModalPaper.js
@@ -50,7 +50,6 @@ export default function ModalPaper({ setModalPaper, posts, setPosts, paperPosts,
 
     // 각 input의 값을 객체로 만들고 posts에 업데이트
     const newPost = {
-      jobId: Math.random().toString(36).substring(2, 11),
       date: dateValue,
       type: "paper",
       company: companyValue,
@@ -64,7 +63,8 @@ export default function ModalPaper({ setModalPaper, posts, setPosts, paperPosts,
     })
       .then((res) => res.json())
       .then((data) => {
-        newPost.id = data
+        newPost.id = data.docId
+        newPost.jobId = data.jobId
         setPosts((prevJobPosts) => [...prevJobPosts, newPost]);
         setPaperPosts((prevJobPosts) => [...prevJobPosts, newPost]);
         setModalPaper(false);

--- a/src/pages/api/post/new.js
+++ b/src/pages/api/post/new.js
@@ -11,7 +11,18 @@ export default async function handler(req, res) {
   if (req.method == "POST") {
     if (JSON.parse(req.body).type == "paper") {
       const jobCollection = collection(db, "job_collection");
-      const jobDocRef = await addDoc(jobCollection, {});
+      const jobDocRef = await addDoc(jobCollection, {
+        paperDate: JSON.parse(req.body).date,
+        interviewDate: "",
+        company: JSON.parse(req.body).company,
+        job: JSON.parse(req.body).job,
+        postLink: JSON.parse(req.body).postLink,
+        files: { resume: [], portfolio: [] },
+        coverLetters: [],
+        reviews: [],
+        overall: "",
+        rating: "",
+      });
 
       const paperData = {
         ...JSON.parse(req.body),
@@ -43,10 +54,25 @@ export default async function handler(req, res) {
       let jobDocRef;
 
       if (JSON.parse(req.body).jobId) {
+        jobDocRef = doc(jobCollection, JSON.parse(req.body).jobId);
+        await updateDoc(jobDocRef, {
+          interviewDate: JSON.parse(req.body).date
+        });
         
       } else {
         // jobId가 존재하지 않는 경우, 새로운 jobCollection 문서 생성
-        jobDocRef = await addDoc(jobCollection, {});
+        jobDocRef = await addDoc(jobCollection, {
+          paperDate: "",
+          interviewDate: JSON.parse(req.body).date,
+          company: JSON.parse(req.body).company,
+          job: JSON.parse(req.body).job,
+          postLink: JSON.parse(req.body).postLink,
+          files: { resume: [], portfolio: [] },
+          coverLetters: [],
+          reviews: [],
+          overall: "",
+          rating: "",
+        });
       }
 
       const interviewData = {

--- a/src/pages/api/post/new.js
+++ b/src/pages/api/post/new.js
@@ -10,8 +10,16 @@ export default async function handler(req, res) {
 
   if (req.method == "POST") {
     if (JSON.parse(req.body).type == "paper") {
+      const jobCollection = collection(db, "job_collection");
+      const jobDocRef = await addDoc(jobCollection, {});
+
+      const paperData = {
+        ...JSON.parse(req.body),
+        jobId: jobDocRef.id, // jobId를 생성된 doc의 id로 설정
+      };
+
       const paperCollection = collection(db, "paper_collection");
-      const docRef = await addDoc(paperCollection, JSON.parse(req.body));
+      const docRef = await addDoc(paperCollection, paperData);
 
       const usersCollection = collection(db, "users_collection")
       const userQuery = query(usersCollection, where("id", "==", userId));
@@ -27,12 +35,27 @@ export default async function handler(req, res) {
         });
       }
 
-      res.status(200).json(docRef.id);
+      res.status(200).json({docId: docRef.id, jobId: jobDocRef.id});
 
 
     } else if (JSON.parse(req.body).type == "interview") {
+      const jobCollection = collection(db, "job_collection");
+      let jobDocRef;
+
+      if (JSON.parse(req.body).jobId) {
+        
+      } else {
+        // jobId가 존재하지 않는 경우, 새로운 jobCollection 문서 생성
+        jobDocRef = await addDoc(jobCollection, {});
+      }
+
+      const interviewData = {
+        ...JSON.parse(req.body),
+        jobId: JSON.parse(req.body).jobId || jobDocRef.id,
+      };
+
       const interviewCollection = collection(db, "interview_collection");
-      const docRef = await addDoc(interviewCollection, JSON.parse(req.body));
+      const docRef = await addDoc(interviewCollection, interviewData);
 
       const usersCollection = collection(db, "users_collection");
       const userQuery = query(usersCollection, where("id", "==", userId));
@@ -49,7 +72,12 @@ export default async function handler(req, res) {
       }
 
 
-      res.status(200).json(docRef.id);
+      let response = { docId: docRef.id };
+      if (!JSON.parse(req.body).jobId) {
+        response.jobId = jobDocRef.id;
+      }
+
+      res.status(200).json(response);
     }
 
     


### PR DESCRIPTION
- 생성된 doc id를 일정의 jobId에도 추가
- 기존 서류에서 면접 일정 추가시 새로 job doc 생성하지 않고, 서류의 jobId 받음